### PR TITLE
added method for opening .xls file from binary

### DIFF
--- a/xls.go
+++ b/xls.go
@@ -25,6 +25,11 @@ func OpenReader(reader io.ReadCloser, charset string) (*WorkBook, error) {
 	}
 }
 
+//Open xls file from binary
+func OpenBinary(bin []byte, charset string) (*WorkBook, error) {
+	return parse(bin, charset)
+}
+
 func parse(bts []byte, charset string) (wb *WorkBook, err error) {
 	var ole *ole2.Ole
 	if ole, err = ole2.Open(bts, charset); err == nil {


### PR DESCRIPTION
For the use case of needing to parse an uploaded .xls received over the network via HTTP/POST. This provides the convenience of not having to figure out the temporary file path. 