### PR TITLE
remove fmt.Println in format.go

### DIFF
--- a/format.go
+++ b/format.go
@@ -1,8 +1,6 @@
 package xls
 
 import (
-	"fmt"
-
 	formatter "github.com/extrame/xls/format"
 )
 
@@ -17,6 +15,5 @@ type format struct {
 func (f *format) Format(val float64, date1904 bool) string {
 	_, tokens := formatter.Lexer(f.str)
 	ds := formatter.Parse(tokens)
-	fmt.Println("=>", val)
 	return ds.Format(val, date1904)
 }


### PR DESCRIPTION
I has using the `new_formatter` branch in a project, when I ran the tests I was having some prints in the terminal. Those prints where from the xls library, that's why I suggest to remove the statement `fmt.Println("=>", val)`