### PR TITLE
Interface extension & bugfix

### DIFF
--- a/col.go
+++ b/col.go
@@ -54,10 +54,10 @@ func (xf *XfRk) String(wb *WorkBook) string {
 		fNo := wb.Xfs[idx].formatNo()
 		if fNo >= 164 { // user defined format
 			if formatter := wb.Formats[fNo]; formatter != nil {
-				if (strings.Contains(formatter.str, "#") || strings.Contains(formatter.str, ".00")){
+				if strings.Contains(formatter.str, "#") || strings.Contains(formatter.str, ".00") {
 					//If format contains # or .00 then this is a number
-					return xf.Rk.String()					
-				}else{
+					return xf.Rk.String()
+				} else {
 					i, f, isFloat := xf.Rk.number()
 					if !isFloat {
 						f = float64(i)
@@ -164,6 +164,18 @@ type NumberCol struct {
 func (c *NumberCol) String(wb *WorkBook) []string {
 	return []string{strconv.FormatFloat(c.Float, 'f', -1, 64)}
 }
+
+type FormulaStringCol struct {
+	Col
+	RenderedValue string
+}
+
+func (c *FormulaStringCol) String(wb *WorkBook) []string {
+	return []string{c.RenderedValue}
+}
+
+//str, err = wb.get_string(buf_item, size)
+//wb.sst[offset_pre] = wb.sst[offset_pre] + str
 
 type FormulaCol struct {
 	Header struct {

--- a/row.go
+++ b/row.go
@@ -35,6 +35,17 @@ func (r *Row) Col(i int) string {
 	return ""
 }
 
+//ColExact Get the Nth Col from the Row, if has not, return nil.
+//For merged cells value is returned for first cell only
+func (r *Row) ColExact(i int) string {
+	serial := uint16(i)
+	if ch, ok := r.cols[serial]; ok {
+		strs := ch.String(r.wb)
+		return strs[0]
+	}
+	return ""
+}
+
 //LastCol Get the number of Last Col of the Row.
 func (r *Row) LastCol() int {
 	return int(r.info.Lcell)

--- a/workbook.go
+++ b/workbook.go
@@ -3,10 +3,10 @@ package xls
 import (
 	"bytes"
 	"encoding/binary"
+	"golang.org/x/text/encoding/charmap"
 	"io"
 	"os"
 	"unicode/utf16"
-	"golang.org/x/text/encoding/charmap"
 )
 
 //xls workbook type
@@ -162,9 +162,9 @@ func (wb *WorkBook) parseBof(buf io.ReadSeeker, b *bof, pre *bof, offset_pre int
 	return
 }
 func decodeWindows1251(enc []byte) string {
-    dec := charmap.Windows1251.NewDecoder()
-    out, _ := dec.Bytes(enc)
-    return string(out)
+	dec := charmap.Windows1251.NewDecoder()
+	out, _ := dec.Bytes(enc)
+	return string(out)
 }
 func (w *WorkBook) get_string(buf io.ReadSeeker, size uint16) (res string, err error) {
 	if w.Is5ver {

--- a/workbook.go
+++ b/workbook.go
@@ -246,7 +246,7 @@ func (w *WorkBook) get_string(buf io.ReadSeeker, size uint16) (res string, err e
 
 func (w *WorkBook) addSheet(sheet *boundsheet, buf io.ReadSeeker) {
 	name, _ := w.get_string(buf, uint16(sheet.Name))
-	w.sheets = append(w.sheets, &WorkSheet{bs: sheet, Name: name, wb: w})
+	w.sheets = append(w.sheets, &WorkSheet{bs: sheet, Name: name, wb: w, Visibility: TWorkSheetVisibility(sheet.Visible)})
 }
 
 //reading a sheet from the compress file to memory, you should call this before you try to get anything from sheet

--- a/worksheet.go
+++ b/worksheet.go
@@ -17,7 +17,7 @@ const (
 
 type boundsheet struct {
 	Filepos uint32
-	Visible TWorkSheetVisibility
+	Visible byte
 	Type    byte
 	Name    byte
 }

--- a/worksheet.go
+++ b/worksheet.go
@@ -213,6 +213,9 @@ func (w *WorkSheet) addContent(row_num uint16, ch contentHandler) {
 		info.Index = row_num
 		row = w.addRow(info)
 	}
+	if row.info.Lcell < ch.LastCol() {
+		row.info.Lcell = ch.LastCol()
+	}
 	row.cols[ch.FirstCol()] = ch
 }
 


### PR DESCRIPTION
1) [Fixed] `boundsheet` field order fixed
2) `WorkSheet.Visibility` implemented (and typed constants)
3) `WorkSheet.Selected` implemented - most of cases require to parse _current_ sheet, not the first one
4) `WorkSheet.rightToLeft` property for future use (not implemented cause no RtL files present)
5) `Row.ColExact(int)(string)` added when we need not to output duplicates of merged cells
6) [Fixed] bug on Row.LastCol() when data is actually present but Row.info.Lcell=0 (ms excel shows the data)