### PR TITLE
Only read required field for BOF record

### DIFF
--- a/bof.go
+++ b/bof.go
@@ -21,10 +21,6 @@ func (b *bof) utf16String(buf io.ReadSeeker, count uint32) string {
 }
 
 type biffHeader struct {
-	Ver     uint16
-	Type    uint16
-	Id_make uint16
-	Year    uint16
-	Flags   uint32
-	Min_ver uint32
+	Ver  uint16
+	Type uint16
 }


### PR DESCRIPTION
There are BIFF8 files that have BOF record with size 8. With current implementation `binary.Read` fails (silently, cause errors are ignored) because struct is 16 bytes. Although standard does specify BOF to be 16 bytes, I've stumbled upon files like that on numerous occasions. 

libxls only reads first 4 bytes as well from BOF.