### PR TITLE
fix datetime xls for yyyy/mm/dd hh:mm:ss

### DIFF
--- a/col.go
+++ b/col.go
@@ -11,7 +11,7 @@ import (
 	yymmdd "github.com/extrame/goyymmdd"
 )
 
-const DDMMYYYYhhmmss = "2006-01-02 15:04:05"
+const DDMMYYYYhhmmss = "2006\\01\\02 15:04:05"
 
 //content type
 type contentHandler interface {

--- a/col.go
+++ b/col.go
@@ -11,7 +11,7 @@ import (
 	yymmdd "github.com/extrame/goyymmdd"
 )
 
-const DDMMYYYYhhmmss = "2006\\01\\02 15:04:05"
+const DDMMYYYYhhmmss = "2006/01/02 15:04:05"
 
 //content type
 type contentHandler interface {

--- a/col.go
+++ b/col.go
@@ -11,6 +11,8 @@ import (
 	yymmdd "github.com/extrame/goyymmdd"
 )
 
+const DDMMYYYYhhmmss = "2006-01-02 15:04:05"
+
 //content type
 type contentHandler interface {
 	String(*WorkBook) []string
@@ -170,6 +172,9 @@ type NumberCol struct {
 func (c *NumberCol) String(wb *WorkBook) []string {
 	if fNo := wb.Xfs[c.Index].formatNo(); fNo != 0 {
 		t := timeFromExcelTime(c.Float, wb.dateMode == 1)
+		if fNo == 176 {
+			return []string{t.Format(DDMMYYYYhhmmss)}
+		}
 		return []string{yymmdd.Format(t, wb.Formats[fNo].str)}
 	}
 	return []string{strconv.FormatFloat(c.Float, 'f', -1, 64)}


### PR DESCRIPTION
Problem: yyyy/mm/dd hh:mm:ss not parsed correctly
Example: 2022/04/26 16:23:47 parsed to 2022/26/26\ 26:26:26

Cause: in xls custom format, yyyy/mm/dd hh:mm:ss was still considered as yyyy/m/d h:mm:ss in excel. 
```return []string{yymmdd.Format(t, wb.Formats[fNo].str)}``` this line is failing to parse the format correctly causing parsing error

Sample data:
[t_event_short.xls](https://github.com/extrame/xls/files/8937975/t_event_short.xls)