### PR TITLE
refactor: optimize Workbook.get_string

### DIFF
--- a/binary_read.go
+++ b/binary_read.go
@@ -1,0 +1,86 @@
+package xls
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+func ReadBytes(r io.Reader, size int) ([]byte, error) {
+	buf := make([]byte, size)
+	if _, err := r.Read(buf); err != nil {
+		return buf, err
+	}
+	return buf, nil
+}
+
+func MustReadBytes(r io.Reader, size int) []byte {
+	buf, _ := ReadBytes(r, size)
+	return buf
+}
+
+func ReadByte(r io.Reader) (byte, error) {
+	buf, err := ReadBytes(r, 1)
+	if err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+func ReadUint16(r io.Reader) (uint16, error) {
+	buf, err := ReadBytes(r, 2)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint16(buf), nil
+}
+
+func ReadUint32(r io.Reader) (uint32, error) {
+	buf, err := ReadBytes(r, 4)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint32(buf), nil
+}
+
+func ReadBoundSheet(r io.Reader) *boundsheet {
+	var bs = new(boundsheet)
+	buf, _ := ReadBytes(r, 7)
+	bs.Filepos = binary.LittleEndian.Uint32(buf[0:4])
+	bs.Visible = buf[4]
+	bs.Type = buf[5]
+	bs.Name = buf[6]
+	return bs
+}
+
+func ReadRowInfo(r io.Reader) *rowInfo {
+	row := new(rowInfo)
+	buf, _ := ReadBytes(r, 16)
+	row.Index = binary.LittleEndian.Uint16(buf[0:2])
+	row.Fcell = binary.LittleEndian.Uint16(buf[2:4])
+	row.Lcell = binary.LittleEndian.Uint16(buf[4:6])
+	row.Height = binary.LittleEndian.Uint16(buf[6:8])
+	row.Notused = binary.LittleEndian.Uint16(buf[8:10])
+	row.Notused2 = binary.LittleEndian.Uint16(buf[10:12])
+	row.Flags = binary.LittleEndian.Uint32(buf[12:16])
+	return row
+}
+
+func ReadLabelsstCol(r io.Reader) *LabelsstCol {
+	col := new(LabelsstCol)
+	buf, _ := ReadBytes(r, 10)
+	col.RowB = binary.LittleEndian.Uint16(buf[0:2])
+	col.FirstColB = binary.LittleEndian.Uint16(buf[2:4])
+	col.Xf = binary.LittleEndian.Uint16(buf[4:6])
+	col.Sst = binary.LittleEndian.Uint32(buf[6:10])
+	return col
+}
+
+func ReadBof(r io.Reader, row *bof) error {
+	buf, err := ReadBytes(r, 4)
+	if err != nil {
+		return err
+	}
+	row.Id = binary.LittleEndian.Uint16(buf[0:2])
+	row.Size = binary.LittleEndian.Uint16(buf[2:4])
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/extrame/xls
+
+go 1.16
+
+require (
+	github.com/extrame/goyymmdd v0.0.0-20210114090516-7cc815f00d1a
+	github.com/extrame/ole2 v0.0.0-20160812065207-d69429661ad7
+	github.com/tealeg/xlsx v1.0.5
+	golang.org/x/text v0.3.7
+)

--- a/worksheet.go
+++ b/worksheet.go
@@ -51,7 +51,8 @@ func (w *WorkSheet) parse(buf io.ReadSeeker) {
 	var bof_pre *bof
 	var col_pre interface{}
 	for {
-		if err := binary.Read(buf, binary.LittleEndian, b); err == nil {
+		//if err := binary.Read(buf, binary.LittleEndian, b); err == nil {
+		if err := ReadBof(buf, b); err == nil {
 			bof_pre, col_pre = w.parseBof(buf, b, bof_pre, col_pre)
 			if b.Id == 0xa {
 				break
@@ -81,8 +82,9 @@ func (w *WorkSheet) parseBof(buf io.ReadSeeker, b *bof, pre *bof, col_pre interf
 		w.rightToLeft = (sheetOptions & 0x40) != 0
 		w.Selected = (sheetOptions & 0x400) != 0
 	case 0x208: //ROW
-		r := new(rowInfo)
-		binary.Read(buf, binary.LittleEndian, r)
+		//r := new(rowInfo)
+		//binary.Read(buf, binary.LittleEndian, r)
+		r := ReadRowInfo(buf)
 		w.addRow(r)
 	case 0x0BD: //MULRK
 		mc := new(MulrkCol)
@@ -129,8 +131,9 @@ func (w *WorkSheet) parseBof(buf io.ReadSeeker, b *bof, pre *bof, col_pre interf
 		col = new(RkCol)
 		binary.Read(buf, binary.LittleEndian, col)
 	case 0xFD: //LABELSST
-		col = new(LabelsstCol)
-		binary.Read(buf, binary.LittleEndian, col)
+		//col = new(LabelsstCol)
+		//binary.Read(buf, binary.LittleEndian, col)
+		col = ReadLabelsstCol(buf)
 	case 0x204:
 		c := new(labelCol)
 		binary.Read(buf, binary.LittleEndian, &c.BlankCol)


### PR DESCRIPTION
## Optimize some binary.Read(), the parsing speed is increased by 10x

- before parse excel with row 65535 cost 139s
- after  parse excel with row 65535 cost 13s

@extrame 